### PR TITLE
fixes a bug "No expression before quantifier" with Saxon-PE 9.5.1.3

### DIFF
--- a/src/content/xqjson.xql
+++ b/src/content/xqjson.xql
@@ -184,7 +184,7 @@ declare %private function xqjson:tokenize($json as xs:string)
   as element(token)*
 {
   let $tokens := ("\{", "\}", "\[", "\]", ":", ",", "true", "false", "null", "\s+",
-    '"(?>[^"\\]|\\"|\\\\|\\/|\\b|\\f|\\n|\\r|\\t|\\u[A-Fa-f0-9][A-Fa-f0-9][A-Fa-f0-9][A-Fa-f0-9])*"',
+    '"([^"\\]|\\"|\\\\|\\/|\\b|\\f|\\n|\\r|\\t|\\u[A-Fa-f0-9][A-Fa-f0-9][A-Fa-f0-9][A-Fa-f0-9])*"',
     "-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+\-]?[0-9]+)?")
   let $regex := string-join(for $t in $tokens return concat("(",$t,")"),"|")
   for $match in analyze-string($json, $regex)/*


### PR DESCRIPTION
Admittedly, I have no idea what these characters are meant to match (looks somewhat like a uncompleted look behind?! )
Funnily, the error doesn’t arise with current eXist -- but eXist’s dashboard/plugins/userManager/jsjson.xqm (which looks like a direct clone of this file) removes these characters as well.
